### PR TITLE
Disable caching of time zones

### DIFF
--- a/src/main/java/io/airlift/jodabridge/JdkBasedZoneInfoProvider.java
+++ b/src/main/java/io/airlift/jodabridge/JdkBasedZoneInfoProvider.java
@@ -16,7 +16,6 @@ package io.airlift.jodabridge;
 
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTimeZone;
-import org.joda.time.tz.CachedDateTimeZone;
 import org.joda.time.tz.Provider;
 
 import java.time.zone.ZoneRulesProvider;
@@ -42,15 +41,6 @@ public class JdkBasedZoneInfoProvider
             }
             else {
                 zone = new JdkBasedDateTimeZone(zoneId);
-            }
-            if (!zone.isFixed()) {
-                // Joda's default Provider implementation, ZoneInfoProvider, caches a zone
-                // most of the time if the zone is not fixed. The exception being zones that
-                // isn't worthwhile from a performance perspective. The actual check is in
-                // `DateTimeZoneBuilder.isCachable` check (a zone would fail if on average
-                // it has a transition less than every 25 days).
-                // This implementation caches everything for simplicity.
-                zone = CachedDateTimeZone.forZone(zone);
             }
             zonesBuilder.put(zoneId, zone);
         }


### PR DESCRIPTION
Remove creation of CachedDateTimeZone for non fixed time zones.
This reduces the excessive number of CachedDateTimeZone$Info instances.